### PR TITLE
Remove using namespace libmv from headers

### DIFF
--- a/src/libmv/correspondence/Array_Matcher_test.cc
+++ b/src/libmv/correspondence/Array_Matcher_test.cc
@@ -53,7 +53,7 @@ TYPED_TEST(MatchingKernelTest, MatcherInterfaceSymmetry)
 {
   int descriptorSize = 2;
   // Build one feature set.
-  FeatureSet featureSet;
+  KeypointFeatureSet featureSet;
   for (int i=0; i < 4; ++i)
   {
     KeypointFeature feat;
@@ -65,7 +65,7 @@ TYPED_TEST(MatchingKernelTest, MatcherInterfaceSymmetry)
 
   // Match feature set between same feature set and assert the result.
   float * data =
-    FeatureSet::FeatureSetDescriptorsToContiguousArray(featureSet);
+    KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(featureSet);
 
   // Build the array matcher in order to compute matches pair.
   libmv::correspondence::ArrayMatcher<float> * pArrayMatcher =
@@ -100,7 +100,7 @@ TYPED_TEST(MatchingKernelTest, MatcherInterface)
 {
   int descriptorSize = 2;
   // Build two feature set.
-  FeatureSet featureSetA;
+  KeypointFeatureSet featureSetA;
   for (int i=0; i < 4; ++i)
   {
     KeypointFeature feat;
@@ -111,7 +111,7 @@ TYPED_TEST(MatchingKernelTest, MatcherInterface)
   }
 
   // Build two feature set.
-  FeatureSet featureSetB;
+  KeypointFeatureSet featureSetB;
   for (int i=0; i < 5; ++i)
   {
     KeypointFeature feat;
@@ -123,9 +123,9 @@ TYPED_TEST(MatchingKernelTest, MatcherInterface)
 
   // Match feature set between same feature set and assert the result.
   float * dataA =
-    FeatureSet::FeatureSetDescriptorsToContiguousArray(featureSetA);
+    KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(featureSetA);
   float * dataB =
-    FeatureSet::FeatureSetDescriptorsToContiguousArray(featureSetB);
+    KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(featureSetB);
 
   // Build the array matcher in order to compute matches pair.
   libmv::correspondence::ArrayMatcher<float> * pArrayMatcherA =

--- a/src/libmv/correspondence/feature_matching.cc
+++ b/src/libmv/correspondence/feature_matching.cc
@@ -25,6 +25,8 @@
 #include "libmv/correspondence/ArrayMatcher_Kdtree_Flann.h"
 #include "libmv/correspondence/ArrayMatcher_Kdtree.h"
 
+namespace libmv {
+
 // Compute candidate matches between 2 sets of features.  Two features A and B
 // are a candidate match if A is the nearest neighbor of B and B is the nearest
 // neighbor of A.
@@ -291,3 +293,5 @@ void FindCorrespondences(const FeatureSet &left,
     LOG(INFO) << "[FindCandidateMatches_Ratio] Unknow input match method.";
   }
 }
+
+} // namespace libmv

--- a/src/libmv/correspondence/feature_matching.cc
+++ b/src/libmv/correspondence/feature_matching.cc
@@ -30,8 +30,8 @@ namespace libmv {
 // Compute candidate matches between 2 sets of features.  Two features A and B
 // are a candidate match if A is the nearest neighbor of B and B is the nearest
 // neighbor of A.
-void FindCandidateMatches(const FeatureSet &left,
-                          const FeatureSet &right,
+void FindCandidateMatches(const KeypointFeatureSet &left,
+                          const KeypointFeatureSet &right,
                           Matches *matches,
                           eLibmvMatchMethod eMatchMethod) {
   if (left.features.size() == 0 ||
@@ -70,8 +70,8 @@ void FindCandidateMatches(const FeatureSet &left,
   if (pArrayMatcherA != NULL && pArrayMatcherB != NULL) {
 
     // Paste the necessary data in contiguous arrays.
-    float * arrayA = FeatureSet::FeatureSetDescriptorsToContiguousArray(left);
-    float * arrayB = FeatureSet::FeatureSetDescriptorsToContiguousArray(right);
+    float * arrayA = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(left);
+    float * arrayB = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(right);
 
     libmv::vector<int> indices, indicesReverse;
     libmv::vector<float> distances, distancesReverse;
@@ -115,8 +115,8 @@ void FindCandidateMatches(const FeatureSet &left,
   }
 }
 
-float * FeatureSet::FeatureSetDescriptorsToContiguousArray
-  ( const FeatureSet & featureSet ) {
+float * KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray
+  ( const KeypointFeatureSet & featureSet ) {
 
   if (featureSet.features.size() == 0)  {
     return NULL;
@@ -134,8 +134,8 @@ float * FeatureSet::FeatureSetDescriptorsToContiguousArray
 }
 
 // Compute candidate matches between 2 sets of features with a ratio.
-void FindCandidateMatches_Ratio(const FeatureSet &left,
-                          const FeatureSet &right,
+void FindCandidateMatches_Ratio(const KeypointFeatureSet &left,
+                          const KeypointFeatureSet &right,
                           Matches *matches,
                           eLibmvMatchMethod eMatchMethod,
                           float fRatio) {
@@ -174,8 +174,8 @@ void FindCandidateMatches_Ratio(const FeatureSet &left,
   if (pArrayMatcherA != NULL) {
 
     // Paste the necessary data in contiguous arrays.
-    float * arrayA = FeatureSet::FeatureSetDescriptorsToContiguousArray(left);
-    float * arrayB = FeatureSet::FeatureSetDescriptorsToContiguousArray(right);
+    float * arrayA = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(left);
+    float * arrayB = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(right);
 
     libmv::vector<int> indices;
     libmv::vector<float> distances;
@@ -218,8 +218,8 @@ void FindCandidateMatches_Ratio(const FeatureSet &left,
 
 
 // Compute correspondences that match between 2 sets of features with a ratio.
-void FindCorrespondences(const FeatureSet &left,
-                         const FeatureSet &right,
+void FindCorrespondences(const KeypointFeatureSet &left,
+                         const KeypointFeatureSet &right,
                          std::map<size_t, size_t> *correspondences,
                          eLibmvMatchMethod eMatchMethod,
                          float fRatio) {
@@ -257,8 +257,8 @@ void FindCorrespondences(const FeatureSet &left,
   if (pArrayMatcherA != NULL) {
 
     // Paste the necessary data in contiguous arrays.
-    float * arrayA = FeatureSet::FeatureSetDescriptorsToContiguousArray(left);
-    float * arrayB = FeatureSet::FeatureSetDescriptorsToContiguousArray(right);
+    float * arrayA = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(left);
+    float * arrayB = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(right);
 
     libmv::vector<int> indices;
     libmv::vector<float> distances;

--- a/src/libmv/correspondence/feature_matching.h
+++ b/src/libmv/correspondence/feature_matching.h
@@ -29,12 +29,12 @@
 #include "libmv/descriptor/descriptor.h"
 #include "libmv/descriptor/vector_descriptor.h"
 
-using namespace libmv;
+namespace libmv {
 
 /// Define the description of a feature described by :
 /// A PointFeature (x,y,scale,orientation),
 /// And a descriptor (a vector of floats).
-struct KeypointFeature : public ::PointFeature {
+struct KeypointFeature : public PointFeature {
   descriptor::VecfDescriptor descriptor;
   // Match kdtree traits: with this, the Feature can act as a kdtree point.
   float operator[](int i) const { return descriptor.coords(i); }
@@ -87,5 +87,7 @@ void FindCorrespondences(const FeatureSet &left,
                          std::map<size_t, size_t> *correspondences,
                          eLibmvMatchMethod eMatchMethod = eMATCH_KDTREE_FLANN,
                          float fRatio = 0.8f);
+
+} // namespace libmv
 
 #endif //LIBMV_CORRESPONDENCE_FEATURE_MATCHING_H_

--- a/src/libmv/correspondence/feature_matching.h
+++ b/src/libmv/correspondence/feature_matching.h
@@ -40,14 +40,14 @@ struct KeypointFeature : public PointFeature {
   float operator[](int i) const { return descriptor.coords(i); }
 };
 
-/// FeatureSet : Store an array of KeypointFeature ( Keypoint and descriptor).
-struct FeatureSet {
+/// KeypointFeatureSet : Store an array of KeypointFeature ( Keypoint and descriptor).
+struct KeypointFeatureSet {
   libmv::vector<KeypointFeature> features;
 
   /// return a float * containing the concatenation of descriptor data.
   /// Must be deleted with []
-  static float *FeatureSetDescriptorsToContiguousArray
-    ( const FeatureSet & featureSet );
+  static float *KeypointFeatureSetDescriptorsToContiguousArray
+    ( const KeypointFeatureSet & featureSet );
 };
 
 enum eLibmvMatchMethod
@@ -60,8 +60,8 @@ enum eLibmvMatchMethod
 // Compute candidate matches between 2 sets of features.  Two features a and b
 // are a candidate match if a is the nearest neighbor of b and b is the nearest
 // neighbor of a.
-void FindCandidateMatches(const FeatureSet &left,
-                          const FeatureSet &right,
+void FindCandidateMatches(const KeypointFeatureSet &left,
+                          const KeypointFeatureSet &right,
                           Matches *matches,
                           eLibmvMatchMethod eMatchMethod = eMATCH_KDTREE_FLANN);
 
@@ -74,16 +74,16 @@ void FindCandidateMatches(const FeatureSet &left,
 // You can use David Lowe's magic ratio (0.6 or 0.8).
 // 0.8 allow to remove 90% of the false matches while discarding less than 5%
 // of the correct matches.
-void FindCandidateMatches_Ratio(const FeatureSet &left,
-                          const FeatureSet &right,
+void FindCandidateMatches_Ratio(const KeypointFeatureSet &left,
+                          const KeypointFeatureSet &right,
                           Matches *matches,
                           eLibmvMatchMethod eMatchMethod = eMATCH_KDTREE_FLANN,
                           float fRatio = 0.8f);
 // TODO(pmoulon) Add Lowe's ratio symmetric match method.
 // Compute correspondences that match between 2 sets of features with a ratio.
 
-void FindCorrespondences(const FeatureSet &left,
-                         const FeatureSet &right,
+void FindCorrespondences(const KeypointFeatureSet &left,
+                         const KeypointFeatureSet &right,
                          std::map<size_t, size_t> *correspondences,
                          eLibmvMatchMethod eMatchMethod = eMATCH_KDTREE_FLANN,
                          float fRatio = 0.8f);

--- a/src/libmv/correspondence/feature_matching_FLANN.cc
+++ b/src/libmv/correspondence/feature_matching_FLANN.cc
@@ -96,8 +96,8 @@ bool FLANN_Wrapper_KDTREE(const FLANN_Data & testSet,const FLANN_Data & dataSet,
 // Compute candidate matches between 2 sets of features.  Two features A and B
 // are a candidate match if A is the nearest neighbor of B and B is the nearest
 // neighbor of A.
-void FindSymmetricCandidateMatches_FLANN(const FeatureSet &left,
-                          const FeatureSet &right,
+void FindSymmetricCandidateMatches_FLANN(const KeypointFeatureSet &left,
+                          const KeypointFeatureSet &right,
                           Matches *matches) {
   // --
   // TODO(pmoulon) template on feature type.
@@ -108,8 +108,8 @@ void FindSymmetricCandidateMatches_FLANN(const FeatureSet &left,
   int descriptorSize = left.features[0].descriptor.coords.size();
 
   // Paste the necessary data in contiguous arrays.
-  float * arrayA = FeatureSet::FeatureSetDescriptorsToContiguousArray(left);
-  float * arrayB = FeatureSet::FeatureSetDescriptorsToContiguousArray(right);
+  float * arrayA = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(left);
+  float * arrayB = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(right);
 
   FLANN_Data dataA={arrayA,left.features.size(),descriptorSize};
   FLANN_Data dataB={arrayB,right.features.size(),descriptorSize};
@@ -147,8 +147,8 @@ void FindSymmetricCandidateMatches_FLANN(const FeatureSet &left,
   }
 }
 
-void FindCandidateMatchesDistanceRatio_FLANN( const FeatureSet &left,
-                                              const FeatureSet &right,
+void FindCandidateMatchesDistanceRatio_FLANN( const KeypointFeatureSet &left,
+                                              const KeypointFeatureSet &right,
                                               Matches *matches,
                                               float fRatio) {
 
@@ -157,8 +157,8 @@ void FindCandidateMatchesDistanceRatio_FLANN( const FeatureSet &left,
   }
   int descriptorSize = left.features[0].descriptor.coords.size();
   // Paste the necessary data in contiguous arrays.
-  float * arrayA = FeatureSet::FeatureSetDescriptorsToContiguousArray(left);
-  float * arrayB = FeatureSet::FeatureSetDescriptorsToContiguousArray(right);
+  float * arrayA = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(left);
+  float * arrayB = KeypointFeatureSet::KeypointFeatureSetDescriptorsToContiguousArray(right);
 
   FLANN_Data dataA={arrayA,left.features.size(),descriptorSize};
   FLANN_Data dataB={arrayB,right.features.size(),descriptorSize};

--- a/src/libmv/correspondence/feature_matching_FLANN.cc
+++ b/src/libmv/correspondence/feature_matching_FLANN.cc
@@ -26,6 +26,8 @@
 // http://www.cs.ubc.ca/~mariusm/index.php/FLANN/FLANN
 // David G. Lowe and Marius Muja
 
+namespace libmv {
+
 bool FLANN_Wrapper_LINEAR(const FLANN_Data & testSet,const FLANN_Data & dataSet,
                   vector<int> * resultIndices, vector<float> * resultDistances,
                   int NumberOfNeighbours)
@@ -186,3 +188,5 @@ void FindCandidateMatchesDistanceRatio_FLANN( const FeatureSet &left,
     }
   }
 }
+
+} // namespace libmv

--- a/src/libmv/correspondence/feature_matching_FLANN.h
+++ b/src/libmv/correspondence/feature_matching_FLANN.h
@@ -35,8 +35,8 @@ namespace libmv {
 // Compute candidate matches between 2 sets of features.  Two features A and B
 // are a candidate match if A is the nearest neighbor of B and B is the nearest
 // neighbor of A.
-void FindSymmetricCandidateMatches_FLANN( const FeatureSet &left,
-                                          const FeatureSet &right,
+void FindSymmetricCandidateMatches_FLANN( const KeypointFeatureSet &left,
+                                          const KeypointFeatureSet &right,
                                           Matches *matches);
 
 // Compute 2 nearest matches of featureSet left in featureSet right.
@@ -47,8 +47,8 @@ void FindSymmetricCandidateMatches_FLANN( const FeatureSet &left,
 // You can use David Lowe's magic ratio (0.6 or 0.8).
 // 0.8 allow to remove 90% of the false matches while discarding less than 5%
 // of the correct matches.
-void FindCandidateMatchesDistanceRatio_FLANN( const FeatureSet &left,
-                                              const FeatureSet &right,
+void FindCandidateMatchesDistanceRatio_FLANN( const KeypointFeatureSet &left,
+                                              const KeypointFeatureSet &right,
                                               Matches *matches,
                                               float fRatio = 0.8f);
 

--- a/src/libmv/correspondence/feature_matching_FLANN.h
+++ b/src/libmv/correspondence/feature_matching_FLANN.h
@@ -29,7 +29,7 @@
 #include "libmv/descriptor/descriptor.h"
 #include "libmv/descriptor/vector_descriptor.h"
 
-using namespace libmv;
+namespace libmv {
 
 
 // Compute candidate matches between 2 sets of features.  Two features A and B
@@ -69,5 +69,5 @@ bool FLANN_Wrapper(const FLANN_Data & testSet,const FLANN_Data & dataSet,
                   vector<int> * resultIndices, vector<float> * resultDistances,
                   int NumberOfNeighbours);
 
-
+} // namespace libmv
 #endif //LIBMV_CORRESPONDENCE_FEATURE_MATCHING_FLANN_H_

--- a/src/libmv/correspondence/import_matches_txt.cc
+++ b/src/libmv/correspondence/import_matches_txt.cc
@@ -26,7 +26,7 @@ namespace libmv {
 
 void ImportMatchesFromTxt(const std::string &input_file, 
                           Matches *matches,
-                          FeatureSet *feature_set) {
+                          KeypointFeatureSet *feature_set) {
   Matches::ImageID image_id = 0;
   Matches::TrackID track_id = 0;
   float x = 0, y = 0;

--- a/src/libmv/correspondence/import_matches_txt.h
+++ b/src/libmv/correspondence/import_matches_txt.h
@@ -31,7 +31,7 @@ namespace libmv {
 // <ImageID> <TrackID> <x> <y>
 void ImportMatchesFromTxt(const std::string &input_file, 
                           Matches *matches,
-                          FeatureSet *feature_set);
+                          KeypointFeatureSet *feature_set);
 }  // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_IMPORT_MATCHES_TXT_H_

--- a/src/libmv/correspondence/nRobustViewMatching.cc
+++ b/src/libmv/correspondence/nRobustViewMatching.cc
@@ -80,8 +80,8 @@ bool nRobustViewMatching::computeData(const string & filename)
     m_pDescriber->Describe(features, im, NULL, &descriptors);
 
     // Copy data.
-    m_ViewData.insert( make_pair(filename,FeatureSet()) );
-    FeatureSet & KeypointData = m_ViewData[filename];
+    m_ViewData.insert( make_pair(filename,KeypointFeatureSet()) );
+    KeypointFeatureSet & KeypointData = m_ViewData[filename];
     KeypointData.features.resize(descriptors.size());
     for(int i = 0;i < descriptors.size(); ++i)
     {

--- a/src/libmv/correspondence/nRobustViewMatching.h
+++ b/src/libmv/correspondence/nRobustViewMatching.h
@@ -133,7 +133,7 @@ private :
   descriptor::Describer * m_pDescriber;
 };
 
-} // using namespace correspondence
-} // using namespace libmv
+} // namespace correspondence
+} // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_N_ROBUST_VIEW_MATCHING_INTERFACE_H_

--- a/src/libmv/correspondence/nRobustViewMatching.h
+++ b/src/libmv/correspondence/nRobustViewMatching.h
@@ -21,7 +21,7 @@
 #ifndef LIBMV_CORRESPONDENCE_N_ROBUST_VIEW_MATCHING_INTERFACE_H_
 #define LIBMV_CORRESPONDENCE_N_ROBUST_VIEW_MATCHING_INTERFACE_H_
 
-struct FeatureSet;
+struct KeypointFeatureSet;
 #include <map>
 #include "libmv/detector/detector.h"
 #include "libmv/descriptor/descriptor.h"
@@ -106,7 +106,7 @@ class nRobustViewMatching :public nViewMatchingInterface  {
   const map< pair<string,string>, Matches> & getSharedData() const
     { return m_sharedData;  }
   /// Return extracted feature over the given image.
-  const map<string,FeatureSet> & getViewData() const
+  const map<string,KeypointFeatureSet> & getViewData() const
     { return m_ViewData;  }
   /// Return detected geometrical consistent matches
   const Matches & getMatches()  const
@@ -116,7 +116,7 @@ private :
   /// Input data names
   libmv::vector<string> m_vec_InputNames;
   /// Data that represent each named element.
-  map<string,FeatureSet> m_ViewData;
+  map<string,KeypointFeatureSet> m_ViewData;
   /// Matches between element named element <A,B>.
   map< pair<string,string>, Matches> m_sharedData;
 

--- a/src/libmv/correspondence/nViewMatchingInterface.h
+++ b/src/libmv/correspondence/nViewMatchingInterface.h
@@ -65,7 +65,7 @@ class nViewMatchingInterface {
   virtual bool computeCrossMatch( const libmv::vector<string> & vec_data)=0;
 };
 
-} // using namespace correspondence
-} // using namespace libmv
+} // namespace correspondence
+} // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_N_VIEW_MATCHING_INTERFACE_H_

--- a/src/libmv/correspondence/planar_tracker.h
+++ b/src/libmv/correspondence/planar_tracker.h
@@ -61,7 +61,7 @@ class PlanarTracker : public Tracker {
   double  rms_threshold_inlier_;
 };
 
-} // using namespace tracker
-} // using namespace libmv
+} // namespace tracker
+} // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_PLANAR_TRACKER_H_

--- a/src/libmv/correspondence/robust_tracker.h
+++ b/src/libmv/correspondence/robust_tracker.h
@@ -60,7 +60,7 @@ class RobustTracker : public Tracker {
   double  rms_threshold_inlier_;
 };
 
-} // using namespace tracker
-} // using namespace libmv
+} // namespace tracker
+} // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_ROBUST_TRACKER_H_

--- a/src/libmv/correspondence/tracker.cc
+++ b/src/libmv/correspondence/tracker.cc
@@ -47,7 +47,7 @@ bool Tracker::Track(const Image &image1,
   
   // Copy data form generic feature to Keypoints since the matcher is
   // a point matcher
-  FeatureSet *feature_set1 = new_features_graph->CreateNewFeatureSet();
+  KeypointFeatureSet *feature_set1 = new_features_graph->CreateNewKeypointFeatureSet();
   feature_set1->features.resize(descriptors1.size());
   for (size_t i = 0; i < descriptors1.size(); i++) {
     KeypointFeature& feature = feature_set1->features[i];
@@ -55,7 +55,7 @@ bool Tracker::Track(const Image &image1,
     *(PointFeature*)(&feature) = *(PointFeature*)features1[i];
   }
   
-  FeatureSet *feature_set2 = new_features_graph->CreateNewFeatureSet();
+  KeypointFeatureSet *feature_set2 = new_features_graph->CreateNewKeypointFeatureSet();
   feature_set2->features.resize(descriptors2.size());
   for (size_t i = 0; i < descriptors2.size(); i++) {
     KeypointFeature& feature = feature_set2->features[i];
@@ -134,7 +134,7 @@ bool Tracker::Track(const Image &image,
   
   // Copy data form generic feature to Keypoints since the matcher is
   // a point matcher
-  FeatureSet *feature_set = new_features_graph->CreateNewFeatureSet();
+  KeypointFeatureSet *feature_set = new_features_graph->CreateNewKeypointFeatureSet();
   feature_set->features.resize(descriptors.size());
   for (size_t i = 0; i < descriptors.size(); i++) {
     KeypointFeature& feature = feature_set->features[i];
@@ -157,7 +157,7 @@ bool Tracker::Track(const Image &image,
       && *iter_image != *image_id; ++iter_image) {
     Matches::Features<KeypointFeature> known_features =
      known_features_graph.matches_.InImage<KeypointFeature>(*iter_image);
-    FeatureSet feature_set_known;
+    KeypointFeatureSet feature_set_known;
     while(known_features) {
       feature_set_known.features.push_back(*known_features.feature());
       known_features.operator++();

--- a/src/libmv/correspondence/tracker.h
+++ b/src/libmv/correspondence/tracker.h
@@ -108,7 +108,7 @@ class Tracker {
    scoped_ptr<correspondence::ArrayMatcher<float> > matcher_;
 };
 
-} // using namespace tracker
-} // using namespace libmv
+} // namespace tracker
+} // namespace libmv
 
 #endif  // LIBMV_CORRESPONDENCE_TRACKER_H_

--- a/src/libmv/correspondence/tracker.h
+++ b/src/libmv/correspondence/tracker.h
@@ -38,8 +38,8 @@ namespace tracker {
 // FeaturesGraph : Store a list of featureSet and its matches.
 struct FeaturesGraph {
  public:
-  FeatureSet * CreateNewFeatureSet() {
-    features_sets_.push_back(new FeatureSet());
+  KeypointFeatureSet * CreateNewKeypointFeatureSet() {
+    features_sets_.push_back(new KeypointFeatureSet());
     return features_sets_.back();
   }
   
@@ -50,7 +50,7 @@ struct FeaturesGraph {
                           feature_graph.features_sets_.end());
   }
   // Erases all the elements.  
-  // Note that this function does not desallocate FeatureSets
+  // Note that this function does not desallocate KeypointFeatureSets
   void Clear() {
     matches_.Clear();
     features_sets_.clear();
@@ -58,7 +58,7 @@ struct FeaturesGraph {
   
   void DeleteAndClear() {
     matches_.Clear();
-    std::list<FeatureSet *>::iterator iter = features_sets_.begin();
+    std::list<KeypointFeatureSet *>::iterator iter = features_sets_.begin();
     for (; iter != features_sets_.end(); ++iter) {
       delete *iter;
     }
@@ -66,7 +66,7 @@ struct FeaturesGraph {
   }
   
   Matches matches_;
-  std::list<FeatureSet *> features_sets_;
+  std::list<KeypointFeatureSet *> features_sets_;
 };
 
 // A tracker is the output of a tracking algorithm, which converts a track into

--- a/src/tools/homography_warping.cc
+++ b/src/tools/homography_warping.cc
@@ -106,8 +106,8 @@ int main(int argc, char **argv) {
   scoped_ptr<detector::Detector> detector(detector::CreateFastDetector(9, 20));
   //scoped_ptr<detector::Detector> detector(detector::CreateSURFDetector(4,4));
 
-  FeatureSet KeypointImgA;
-  FeatureSet KeypointImgB;
+  KeypointFeatureSet KeypointImgA;
+  KeypointFeatureSet KeypointImgB;
   {
     Array3Du imageTemp;
     Rgb2Gray( imageA, &imageTemp);

--- a/src/tools/mosaicing_video.cc
+++ b/src/tools/mosaicing_video.cc
@@ -368,7 +368,7 @@ int main(int argc, char **argv) {
   }
   // Imports matches
   tracker::FeaturesGraph fg;
-  FeatureSet *fs = fg.CreateNewFeatureSet();
+  KeypointFeatureSet *fs = fg.CreateNewKeypointFeatureSet();
   VLOG(0) << "Loading Matches file..." << std::endl;
   ImportMatchesFromTxt(FLAGS_m, &fg.matches_, fs);
   VLOG(0) << "Loading Matches file...[DONE]." << std::endl;

--- a/src/tools/reconstruct_video.cc
+++ b/src/tools/reconstruct_video.cc
@@ -67,7 +67,7 @@ int main (int argc, char *argv[]) {
 
   // Imports matches
   tracker::FeaturesGraph fg;
-  FeatureSet *fs = fg.CreateNewFeatureSet();
+  KeypointFeatureSet *fs = fg.CreateNewKeypointFeatureSet();
   
   VLOG(0) << "Loading Matches file..." << std::endl;
   ImportMatchesFromTxt(FLAGS_i, &fg.matches_, fs);

--- a/src/tools/stabilize.cc
+++ b/src/tools/stabilize.cc
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
   std::sort(files.begin(), files.end());
   // Imports matches
   tracker::FeaturesGraph fg;
-  FeatureSet *fs = fg.CreateNewFeatureSet();
+  KeypointFeatureSet *fs = fg.CreateNewKeypointFeatureSet();
   VLOG(0) << "Loading Matches file..." << std::endl;
   ImportMatchesFromTxt(FLAGS_m, &fg.matches_, fs);
   VLOG(0) << "Loading Matches file...[DONE]." << std::endl;

--- a/src/ui/nvr/nview.cpp
+++ b/src/ui/nvr/nview.cpp
@@ -420,7 +420,7 @@ void MainWindow::LoadMatches() {
   if (s.isEmpty()) return;
  
   // Imports matches
-  libmv::FeatureSet *fs = new libmv::FeatureSet();
+  libmv::KeypointFeatureSet *fs = new libmv::KeypointFeatureSet();
   ImportMatchesFromTxt(s.toStdString(), &matches_, fs);
   UpdateGraph();
   is_video_sequence_ = true;

--- a/src/ui/nvr/nview.cpp
+++ b/src/ui/nvr/nview.cpp
@@ -420,7 +420,7 @@ void MainWindow::LoadMatches() {
   if (s.isEmpty()) return;
  
   // Imports matches
-  FeatureSet *fs = new FeatureSet();
+  libmv::FeatureSet *fs = new libmv::FeatureSet();
   ImportMatchesFromTxt(s.toStdString(), &matches_, fs);
   UpdateGraph();
   is_video_sequence_ = true;

--- a/src/ui/tvr/main_window.cc
+++ b/src/ui/tvr/main_window.cc
@@ -283,7 +283,7 @@ void TvrMainWindow::ComputeFeatures(int image_index) {
 
   QImage &qimage = document_.images[image_index];
   int width = qimage.width(), height = qimage.height();
-  FeatureSet &fs = document_.feature_sets[image_index];
+  KeypointFeatureSet &fs = document_.feature_sets[image_index];
 
   // Convert to gray-scale.
   // TODO(keir): Make a libmv image <-> QImage interop library inside libmv for

--- a/src/ui/tvr/tvr_document.h
+++ b/src/ui/tvr/tvr_document.h
@@ -31,7 +31,7 @@ using libmv::vector;
 
 struct TvrDocument {
   QImage images[2];
-  libmv::FeatureSet feature_sets[2];
+  libmv::KeypointFeatureSet feature_sets[2];
   libmv::Matches matches;
   libmv::Mat3 F;
   double focal_distance[2];

--- a/src/ui/tvr/tvr_document.h
+++ b/src/ui/tvr/tvr_document.h
@@ -31,7 +31,7 @@ using libmv::vector;
 
 struct TvrDocument {
   QImage images[2];
-  FeatureSet feature_sets[2];
+  libmv::FeatureSet feature_sets[2];
   libmv::Matches matches;
   libmv::Mat3 F;
   double focal_distance[2];


### PR DESCRIPTION
This avoid name clashes when using libmv as a library.
Also require the renaming of one of the two FeatureSet class defined to avoid name clash.
