### PR TITLE
Fix for: Compilation failure due to missing OpenGL utility file includes

### DIFF
--- a/src/ui/tvr/3D_viewer.cc
+++ b/src/ui/tvr/3D_viewer.cc
@@ -21,6 +21,7 @@
 #include "ui/tvr/3D_viewer.h"
 
 #include <QtGui>
+#include <GL/glu.h>
 #include <QtOpenGL>
 
 using namespace libmv::scene;

--- a/src/ui/tvr/main_window.cc
+++ b/src/ui/tvr/main_window.cc
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
+#include <GL/glu.h>
 #include <QMenuBar>
 #include <QFileDialog>
 #include <QtGui>

--- a/src/ui/tvr/match_viewer.cc
+++ b/src/ui/tvr/match_viewer.cc
@@ -23,6 +23,7 @@
 #endif //_WIN32
 
 #include <QtGui>
+#include <GL/glu.h>
 #include <QtOpenGL>
 #include <cmath>
 


### PR DESCRIPTION
Hi,

when I tried to compile libmv I ran into 3 compilation errors. Everytime a GLU function was not declared.

As an example:
libmv/src/ui/tvr/main_window.cc:252:61: error: 'gluBuild2DMipmaps' was not declared in this scope

The problems only occur with files under the libmv/src/ui/tvr/ directory.

This pull request fixes these problems by including GL/glu.h at the correct spots.

Cheers,
Konrad
